### PR TITLE
v2.0.0 Truncated Normal

### DIFF
--- a/treat_sim/distributions.py
+++ b/treat_sim/distributions.py
@@ -139,8 +139,10 @@ class Normal:
     '''
     Convenience class for the normal distribution.
     packages up distribution parameters, seed and random generator.
+
+    Use the minimum parameter to truncate the distribution
     '''
-    def __init__(self, mean, sigma, random_seed=None):
+    def __init__(self, mean, sigma, minimum=None, random_seed=None):
         '''
         Constructor
         
@@ -159,6 +161,7 @@ class Normal:
         self.rng = np.random.default_rng(seed=random_seed)
         self.mean = mean
         self.sigma = sigma
+        self.minimum = minimum
         
     def sample(self, size=None):
         '''
@@ -170,7 +173,17 @@ class Normal:
             the number of samples to return.  If size=None then a single
             sample is returned.
         '''
-        return self.rng.normal(self.mean, self.sigma, size=size)
+        samples = self.rng.normal(self.mean, self.sigma, size=size)
+
+        if self.minimum is None:
+            return samples
+        elif size is None:
+            return max(self.minimum, samples)
+        else:
+            # index of samples with negative value
+            neg_idx = np.where(samples < 0)[0]
+            samples[neg_idx] = self.minimum
+            return samples
 
     
 class Uniform():

--- a/treat_sim/model.py
+++ b/treat_sim/model.py
@@ -49,6 +49,7 @@ DEFAULT_REG_VAR= 2.0
 # examination parameters
 DEFAULT_EXAM_MEAN = 16.0
 DEFAULT_EXAM_VAR = 3.0
+DEFAULT_EXAM_MIN = 0.5
 
 # trauma/stabilisation
 DEFAULT_TRAUMA_MEAN = 90.0
@@ -178,6 +179,7 @@ class Scenario:
                  reg_var=DEFAULT_REG_VAR,
                  exam_mean=DEFAULT_EXAM_MEAN,
                  exam_var=DEFAULT_EXAM_VAR,
+                 exam_min=DEFAULT_EXAM_MIN,
                  trauma_mean=DEFAULT_TRAUMA_MEAN,
                  trauma_treat_mean=DEFAULT_TRAUMA_TREAT_MEAN,
                  trauma_treat_var=DEFAULT_TRAUMA_TREAT_VAR,
@@ -226,6 +228,9 @@ class Scenario:
             
         exam_var: float
             Variance of the examination distribution (Normal)
+
+        exam_min: float
+            The minimum value that an examination can take (Truncated Normal)
             
         trauma_mean: float
             Mean of the trauma stabilisation distribution (Exponential)
@@ -257,6 +262,7 @@ class Scenario:
         self.reg_var = reg_var
         self.exam_mean= exam_mean
         self.exam_var = exam_var
+        self.exam_min = exam_min
         self.trauma_mean = trauma_mean
         self.trauma_treat_mean = trauma_treat_mean
         self.trauma_treat_var = trauma_treat_var
@@ -322,6 +328,7 @@ class Scenario:
         # Evaluation (non-trauma only)
         self.exam_dist = Normal(self.exam_mean,
                                 np.sqrt(self.exam_var),
+                                minimum=self.exam_min,
                                 random_seed=self.seeds[2])
         
         # Trauma/stablisation duration (trauma only)


### PR DESCRIPTION
## Changes

* Examination now uses truncated normal distribution (minimum 0.5) to avoid negative samples if a user selects a small mean value.